### PR TITLE
Feat/Fix: New setting configuration and auth class function fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.8
+
+Features:
+- Add new setting configuration "ENABLE_AUTH_RESTRICTION" to allow users enable/disable channel restrictions.
+
+Fixes:
+- Auth classes no longer raise errors on failure, this function will now be left to DRF permission classes.
+- Update AuthToken private method __generate_token to return token string not token instance.
+
 ## 0.3.7
 
 Fixes:

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ For a one type fits all case, you can globally alter the following settings, or 
 
 ```python
 DRF_AUTHENTIFY = {
-    "ALLOWED_HEADER_PREFIXES": ["bearer", "token"] # default
-    "TOKEN_EXPIRATION": 3000 # default
-    "COOKIE_KEY": "token" # default
+    "COOKIE_KEY": "token", 
+    "TOKEN_EXPIRATION": 3000,
+    "ENABLE_AUTH_RESTRICTION": False,
+    "ALLOWED_HEADER_PREFIXES": ["bearer", "token"],
 }
 ```
 
@@ -70,6 +71,8 @@ DRF_AUTHENTIFY = {
 - COOKIE_KEY: With this, you can customize what key we should use to retrieve your authentication cookie frmo each request. We will also validate this when you apply our authentication scheme `drf_authentify.auth.CookieAuthentication` as shown below.
 
 - TOKEN_EXPIRATION: With this you can globally set the duration of each token generated, this can also be set per view, as you would see below.
+
+- ENABLE_AUTH_RESTRICTION: This can be used to disable/enable checks for authorization channels (cookie or authorization header). 
 
 > **Note:**
 > Do not forget to add custom header prefixes to your cors-header as this could cause cors errors.

--- a/drf_authentify/auth.py
+++ b/drf_authentify/auth.py
@@ -1,4 +1,3 @@
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.authentication import BaseAuthentication
 
 from drf_authentify.choices import AUTH
@@ -13,10 +12,16 @@ class TokenAuthentication(BaseAuthentication):
         if "HTTP_AUTHORIZATION" in request.META:
             token_str = self.authenticate_header(request)
             if token_str:
-                token = AuthToken.verify_token(token_str, AUTH.TOKEN)
+
+                # if auth restriction is enabled, then filter for token with token auth
+                if authentify_settings.ENABLE_AUTH_RESTRICTION:
+                    token = AuthToken.verify_token(token_str, AUTH.TOKEN)
+                else:
+                    token = AuthToken.verify_token(token_str)
+
                 if token:
                     return (token.user, token)
-            raise AuthenticationFailed()
+
         return None
 
     def authenticate_header(self, request):
@@ -37,10 +42,16 @@ class CookieAuthentication(BaseAuthentication):
         if authentify_settings.COOKIE_KEY in request.COOKIES:
             token_str = request.COOKIES[authentify_settings.COOKIE_KEY]
             if token_str:
-                token = AuthToken.verify_token(token_str, AUTH.COOKIE)
+
+                # if auth restriction is enabled, then filter for token with auth
+                if authentify_settings.ENABLE_AUTH_RESTRICTION:
+                    token = AuthToken.verify_token(token_str, AUTH.COOKIE)
+                else:
+                    token = AuthToken.verify_token(token_str)
+
                 if token:
                     return (token.user, token)
-            raise AuthenticationFailed()
+
         return None
 
     def authenticate_header(self, request):

--- a/drf_authentify/settings.py
+++ b/drf_authentify/settings.py
@@ -9,6 +9,7 @@ DEFAULTS = {
     "ALLOWED_HEADER_PREFIXES": ["bearer", "token"],
     "TOKEN_EXPIRATION": 3000,
     "COOKIE_KEY": "token",
+    "ENABLE_AUTH_RESTRICTION": False,
 }
 
 authentify_settings = APISettings(USER_SETTINGS, DEFAULTS)

--- a/drf_authentify/tests/test_models.py
+++ b/drf_authentify/tests/test_models.py
@@ -140,67 +140,81 @@ class TestAuthTokenModelMethods(TestCase):
 
     def test_cookie_generate_token(self):
         token = AuthToken.generate_cookie_token(self.user, context={"role": "admin"})
+        self.assertIsInstance(token, str)
 
-        self.assertIsInstance(token, AuthToken)
-        self.assertEqual(token.user, self.user)
-        self.assertEqual(token.auth, AUTH.COOKIE)
-        self.assertDictEqual(token.context, {"role": "admin"})
+        token_instance = AuthToken.objects.filter(token=token).first()
+
+        self.assertIsInstance(token_instance, AuthToken)
+        self.assertEqual(token_instance.user, self.user)
+        self.assertEqual(token_instance.auth, AUTH.COOKIE)
+        self.assertDictEqual(token_instance.context, {"role": "admin"})
 
         self.assertAlmostEqual(
-            token.expires_at,
-            token.created_at + timedelta(seconds=authentify_settings.TOKEN_EXPIRATION),
-            delta=timedelta(seconds=5),
+            token_instance.expires_at,
+            token_instance.created_at
+            + timedelta(seconds=authentify_settings.TOKEN_EXPIRATION),
+            delta=timedelta(seconds=10),
         )
 
-        token.delete()
+        token_instance.delete()
 
     def test_cookie_generate_token_variety(self):
         token = AuthToken.generate_cookie_token(self.user, expires=100)
+        self.assertIsInstance(token, str)
 
-        self.assertIsInstance(token, AuthToken)
-        self.assertEqual(token.user, self.user)
-        self.assertEqual(token.auth, AUTH.COOKIE)
-        self.assertIsNone(token.context)
+        token_instance = AuthToken.objects.filter(token=token).first()
+
+        self.assertIsInstance(token_instance, AuthToken)
+        self.assertEqual(token_instance.user, self.user)
+        self.assertEqual(token_instance.auth, AUTH.COOKIE)
+        self.assertIsNone(token_instance.context)
 
         self.assertAlmostEqual(
-            token.expires_at,
-            token.created_at + timedelta(seconds=100),
-            delta=timedelta(seconds=5),
+            token_instance.expires_at,
+            token_instance.created_at + timedelta(seconds=100),
+            delta=timedelta(seconds=10),
         )
 
-        token.delete()
+        token_instance.delete()
 
     def test_token_type_generate_token(self):
         token = AuthToken.generate_header_token(self.user, context={"role": "admin"})
+        self.assertIsInstance(token, str)
 
-        self.assertIsInstance(token, AuthToken)
-        self.assertEqual(token.user, self.user)
-        self.assertEqual(token.auth, AUTH.TOKEN)
-        self.assertDictEqual(token.context, {"role": "admin"})
+        token_instance = AuthToken.objects.filter(token=token).first()
+
+        self.assertIsInstance(token_instance, AuthToken)
+        self.assertEqual(token_instance.user, self.user)
+        self.assertEqual(token_instance.auth, AUTH.TOKEN)
+        self.assertDictEqual(token_instance.context, {"role": "admin"})
 
         self.assertAlmostEqual(
-            token.expires_at,
-            token.created_at + timedelta(seconds=authentify_settings.TOKEN_EXPIRATION),
-            delta=timedelta(seconds=5),
+            token_instance.expires_at,
+            token_instance.created_at
+            + timedelta(seconds=authentify_settings.TOKEN_EXPIRATION),
+            delta=timedelta(seconds=10),
         )
 
-        token.delete()
+        token_instance.delete()
 
     def test_token_type_generate_token_variety(self):
         token = AuthToken.generate_header_token(self.user, expires=1000)
+        self.assertIsInstance(token, str)
 
-        self.assertIsInstance(token, AuthToken)
-        self.assertEqual(token.user, self.user)
-        self.assertEqual(token.auth, AUTH.TOKEN)
-        self.assertIsNone(token.context)
+        token_instance = AuthToken.objects.filter(token=token).first()
+
+        self.assertIsInstance(token_instance, AuthToken)
+        self.assertEqual(token_instance.user, self.user)
+        self.assertEqual(token_instance.auth, AUTH.TOKEN)
+        self.assertIsNone(token_instance.context)
 
         self.assertAlmostEqual(
-            token.expires_at,
-            token.created_at + timedelta(seconds=1000),
-            delta=timedelta(seconds=5),
+            token_instance.expires_at,
+            token_instance.created_at + timedelta(seconds=1000),
+            delta=timedelta(seconds=10),
         )
 
-        token.delete()
+        token_instance.delete()
 
     def test_verify_token(self):
         token1 = self.__create_extra_token_data(AUTH.TOKEN, expires=2000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "drf-authentify"
-version = "0.3.7"
+version = "0.3.8"
 description = "A simple authentication module for django rest framework"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}


### PR DESCRIPTION
Features:
- Add new setting configuration "ENABLE_AUTH_RESTRICTION" to allow users enable/disable channel restrictions.

Fixes:
- Auth classes no longer raise errors on failure, this function will now be left to DRF permission classes.
- Update AuthToken private method __generate_token to return token string not token instance.