### PR TITLE
fix: add type hinting compability for older python versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.1] - 2025-11-14
+
+### Change
+- Add compatibility for older python versions for typehinting, older version will use typing_extensions, and newer versions will use typing standard module.
+
+
 ## [0.5] - 2025-11-14
 
 ### Added
@@ -10,6 +16,7 @@
 
 ### Expected
 - Invalidated all project tests, new tests will added shortly.
+
 
 ## [0.4] - 2025-05-05
 
@@ -30,20 +37,24 @@
 ### Docs
 - Updated documentation.
 
+
 ## [0.3.11]
 
 ### Fixed
 - Fixed issue with non-existing document on PyPI.
+
 
 ## [0.3.10]
 
 ### Fixed
 - Fixed error in `TokenAuthentication.authenticate` method (was not updated after `authentication_header` method was changed).
 
+
 ## [0.3.9]
 
 ### Fixed
 - Fixed error in `Auth.authentication_header` method.
+
 
 ## [0.3.8]
 
@@ -54,16 +65,19 @@
 - Auth classes no longer raise errors on failure; responsibility is now delegated to DRF permission classes.
 - Updated `AuthToken.__generate_token()` to return token string instead of token instance.
 
+
 ## [0.3.7]
 
 ### Fixed
 - Fixed condition check in `authenticate_header` method of token auth class.
+
 
 ## [0.3.6]
 
 ### Fixed
 - Fixed auth class accessing the wrong method.
 - Updated `authenticate_header` in auth classes.
+
 
 ## [0.3.5]
 
@@ -73,11 +87,13 @@
 ### Fixed
 - Fixed auth class accessing an invalid variable.
 
+
 ## [0.3.4]
 
 ### Fixed
 - Fixed documentation URLs in `pyproject.toml`.
 - Fixed changelog URLs in `pyproject.toml`.
+
 
 ## [0.3.0]
 

--- a/drf_authentify/compat.py
+++ b/drf_authentify/compat.py
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self, Type, TYPE_CHECKING
+else:
+    from typing_extensions import Self, Type, TYPE_CHECKING

--- a/drf_authentify/managers.py
+++ b/drf_authentify/managers.py
@@ -1,11 +1,10 @@
-from typing import Self
 from datetime import timedelta
 
 from django.db.models import Q
 from django.utils import timezone
-from django.db.models import Model
 from django.db import models, transaction
 
+from drf_authentify.compat import Self
 from drf_authentify.choices import AUTH_TYPES
 from drf_authentify.types import GeneratedToken
 from drf_authentify.utils import generate_token

--- a/drf_authentify/models.py
+++ b/drf_authentify/models.py
@@ -1,11 +1,10 @@
-from typing import Type
-
 from django.apps import apps
 from django.db import models
 from django.conf import settings
 from django.utils import timezone
 from django.utils.module_loading import import_string
 
+from drf_authentify.compat import Type
 from drf_authentify.choices import AUTH_TYPES
 from drf_authentify.contexts import ContextParams
 from drf_authentify.validators import validate_dict

--- a/drf_authentify/types.py
+++ b/drf_authentify/types.py
@@ -1,5 +1,6 @@
-from typing import TYPE_CHECKING
 from dataclasses import dataclass
+
+from drf_authentify.compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from drf_authentify.models import TokenType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "drf-authentify"
-version = "0.5"
+version = "0.5.1"
 description = "A simple authentication module for django rest framework"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
@@ -18,6 +18,7 @@ requires-python = ">=3.8"
 dependencies = [
     "Django >= 3.2",
     "djangorestframework >= 3.1",
+    "typing_extensions; python_version < '3.11'",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
- >= python 3.11 use typing standard module, and
- <= python 3.11 use typing_extensions