### PR TITLE
v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.5.7] - 2025-11-14
+
+### Change
+- TokenService method refresh_token not formatting custom value expires_in properly before calling generate token internal utility method.
+
 ## [0.5.6] - 2025-11-14
 
 ### Change

--- a/drf_authentify/services.py
+++ b/drf_authentify/services.py
@@ -127,6 +127,7 @@ class TokenService:
             token.delete()
 
         # Create new token
+        expires_timedelta = timedelta(seconds=expires_in) if expires_in else None
         return TokenService._generate_auth_token(
-            user=user, auth_type=auth_type, context=context, expires_in=expires_in
+            user=user, auth_type=auth_type, context=context, expires_in=expires_timedelta
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "drf-authentify"
-version = "0.5.6"
+version = "0.5.7"
 description = "A simple authentication module for django rest framework"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}


### PR DESCRIPTION
- TokenService method refresh_token not formatting custom value expires_in properly before calling generate token internal utility method.